### PR TITLE
Remove deprecation error

### DIFF
--- a/pesel/pesel.py
+++ b/pesel/pesel.py
@@ -1,7 +1,7 @@
 """Implementation module of Pesel Class"""
 
 import random
-from datetime import datetime
+import time
 import calendar
 
 
@@ -135,7 +135,7 @@ class Pesel:
         :return: instance of class Pesel
         :rtype: pesel.Pesel
         """
-        random.seed(datetime.now())
+        random.seed(time.time())
 
         gender = int(male) if male is not None else random.randint(0, 1)
 

--- a/tests/test_cli_pesel.py
+++ b/tests/test_cli_pesel.py
@@ -1,9 +1,9 @@
 from pesel.main import cli
 import pytest
 import random
-from datetime import datetime
+import time
 
-random.seed(datetime.now())
+random.seed(time.time())
 
 
 @pytest.mark.parametrize('mock', [_ for _ in range(10)])

--- a/tests/test_incorrect_pesel.py
+++ b/tests/test_incorrect_pesel.py
@@ -1,9 +1,9 @@
 from pesel import Pesel
 import random
-from datetime import datetime
+import time
 import pytest
 
-random.seed(datetime.now())
+random.seed(time.time())
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Seeding based on hashing is deprecated
since Python 3.9 and will be removed in a subsequent version. The only
supported seed types are: None, int, float, str, bytes, and bytearray.